### PR TITLE
Issue #8: Fix issue with Discover select box

### DIFF
--- a/app/pages/discover.html
+++ b/app/pages/discover.html
@@ -7,7 +7,6 @@
     <movie-page-wrapper>
       <movie-page-padding>
         <movie-page-title></movie-page-title>
-        <movie-sort-select></movie-sort-select>
         <movie-grid></movie-grid>
         <movie-pagination></movie-pagination>
       </movie-page-padding>


### PR DESCRIPTION
I removed the sorting dropbox from the Discover routes. I don't think it needs to be there as Discover is sorted by the type of movie you are discovering.