### PR TITLE
YouTube without JS

### DIFF
--- a/app/elements/movie-feature.mjs
+++ b/app/elements/movie-feature.mjs
@@ -2,7 +2,8 @@ export default function MovieFeature({ html, state }) {
   const { store } = state
   const { featured } = store
   const { backdrop_path, title, overview, id, trailer } = featured
-  const trailerUrl = trailer?.key && `https://www.youtube.com/embed/${trailer.key}?rel=0&autoplay=0&showinfo=0`
+  const embeddedTrailerUrl = trailer?.key && `https://www.youtube.com/embed/${trailer.key}?rel=0&autoplay=0&showinfo=0`
+  const trailerUrl = trailer?.key && `https://www.youtube.com/watch?v=${trailer.key}`
 
   return html`
     <style>
@@ -34,7 +35,7 @@ export default function MovieFeature({ html, state }) {
             More Info
           </primary-link-button>
           ${trailer ? `
-            <movie-trailer-modal href="${trailerUrl}" id="${id}"></movie-trailer-modal>
+            <movie-trailer-modal embedded="${embeddedTrailerUrl}" trailer="${trailerUrl}" id="${id}"></movie-trailer-modal>
           ` : ''}
         </div>
       </div>

--- a/app/elements/movie-trailer-modal.mjs
+++ b/app/elements/movie-trailer-modal.mjs
@@ -1,6 +1,6 @@
 export default function MovieTrailerModal({ html, state }) {
   const { attrs } = state
-  const { id, href } = attrs
+  const { id, embedded, trailer } = attrs
 
   return html`
     <style>
@@ -43,7 +43,7 @@ export default function MovieTrailerModal({ html, state }) {
         aspect-ratio: var(--aspect-ratio);
       }
     </style>
-    <secondary-link-button href="${href}" data-movie="${id}">
+    <secondary-link-button href="${trailer}" data-movie="${id}">
       Trailer
       <svg height="20" width="14" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
         <use xlink:href="#svg-play-button">
@@ -55,7 +55,7 @@ export default function MovieTrailerModal({ html, state }) {
           &times;
         </button>
       </form>
-      <iframe allowfullscreen allow="fullscreen; autoplay" src="${href}" loading="lazy" class="si-100 sb-100"></iframe>
+      <iframe allowfullscreen allow="fullscreen; autoplay" src="${embedded}" loading="lazy" class="si-100 sb-100"></iframe>
     </dialog>
   `
 }


### PR DESCRIPTION
YouTube Embed with JS disabled looks like this:

![Screenshot 2023-06-27 at 13 52 38](https://github.com/enhance-dev/enhance-movie/assets/353180/62ef9dae-0b55-4901-9b53-efab8c319e13)

This change will send the user to the YouTube site if JS is off. They still won't be able to watch the video but at least it doesn't look like an error on our site.